### PR TITLE
Fix: Order packages by name

### DIFF
--- a/alpine/3.12/7.3/Dockerfile
+++ b/alpine/3.12/7.3/Dockerfile
@@ -70,17 +70,17 @@ ARG CFLAGS="-I/usr/src/php"
 RUN apk update \
     && apk add --no-cache \
     bash \
+    coreutils \
     curl \
     git \
-    unzip \
     graphviz \
-    netcat-openbsd \
     mysql-client \
+    netcat-openbsd \
     openssh \
     postgresql-client \
     procps \
     shadow \
-    coreutils \
+    unzip \
     ${PHP_RUN_DEPS} \
     && \
     apk add --no-cache --virtual .php-build-deps ${PHP_BUILD_DEPS} \

--- a/alpine/3.12/7.4/Dockerfile
+++ b/alpine/3.12/7.4/Dockerfile
@@ -70,17 +70,17 @@ ARG CFLAGS="-I/usr/src/php"
 RUN apk update \
     && apk add --no-cache \
     bash \
+    coreutils \
     curl \
     git \
-    unzip \
     graphviz \
-    netcat-openbsd \
     mysql-client \
+    netcat-openbsd \
     openssh \
     postgresql-client \
     procps \
     shadow \
-    coreutils \
+    unzip \
     ${PHP_RUN_DEPS} \
     && \
     apk add --no-cache --virtual .php-build-deps ${PHP_BUILD_DEPS} \

--- a/alpine/3.12/8.0/Dockerfile
+++ b/alpine/3.12/8.0/Dockerfile
@@ -70,17 +70,17 @@ ARG CFLAGS="-I/usr/src/php"
 RUN apk update \
     && apk add --no-cache \
     bash \
+    coreutils \
     curl \
     git \
-    unzip \
     graphviz \
-    netcat-openbsd \
     mysql-client \
+    netcat-openbsd \
     openssh \
     postgresql-client \
     procps \
     shadow \
-    coreutils \
+    unzip \
     ${PHP_RUN_DEPS} \
     && \
     apk add --no-cache --virtual .php-build-deps ${PHP_BUILD_DEPS} \

--- a/alpine/3.13/7.4/Dockerfile
+++ b/alpine/3.13/7.4/Dockerfile
@@ -70,17 +70,17 @@ ARG CFLAGS="-I/usr/src/php"
 RUN apk update \
     && apk add --no-cache \
     bash \
+    coreutils \
     curl \
     git \
-    unzip \
     graphviz \
-    netcat-openbsd \
     mysql-client \
+    netcat-openbsd \
     openssh \
     postgresql-client \
     procps \
     shadow \
-    coreutils \
+    unzip \
     ${PHP_RUN_DEPS} \
     && \
     apk add --no-cache --virtual .php-build-deps ${PHP_BUILD_DEPS} \

--- a/alpine/3.13/8.0/Dockerfile
+++ b/alpine/3.13/8.0/Dockerfile
@@ -70,17 +70,17 @@ ARG CFLAGS="-I/usr/src/php"
 RUN apk update \
     && apk add --no-cache \
     bash \
+    coreutils \
     curl \
     git \
-    unzip \
     graphviz \
-    netcat-openbsd \
     mysql-client \
+    netcat-openbsd \
     openssh \
     postgresql-client \
     procps \
     shadow \
-    coreutils \
+    unzip \
     ${PHP_RUN_DEPS} \
     && \
     apk add --no-cache --virtual .php-build-deps ${PHP_BUILD_DEPS} \

--- a/alpine/3.14/7.4/Dockerfile
+++ b/alpine/3.14/7.4/Dockerfile
@@ -70,17 +70,17 @@ ARG CFLAGS="-I/usr/src/php"
 RUN apk update \
     && apk add --no-cache \
     bash \
+    coreutils \
     curl \
     git \
-    unzip \
     graphviz \
-    netcat-openbsd \
     mysql-client \
+    netcat-openbsd \
     openssh \
     postgresql-client \
     procps \
     shadow \
-    coreutils \
+    unzip \
     ${PHP_RUN_DEPS} \
     && \
     apk add --no-cache --virtual .php-build-deps ${PHP_BUILD_DEPS} \

--- a/alpine/3.14/8.0/Dockerfile
+++ b/alpine/3.14/8.0/Dockerfile
@@ -70,17 +70,17 @@ ARG CFLAGS="-I/usr/src/php"
 RUN apk update \
     && apk add --no-cache \
     bash \
+    coreutils \
     curl \
     git \
-    unzip \
     graphviz \
-    netcat-openbsd \
     mysql-client \
+    netcat-openbsd \
     openssh \
     postgresql-client \
     procps \
     shadow \
-    coreutils \
+    unzip \
     ${PHP_RUN_DEPS} \
     && \
     apk add --no-cache --virtual .php-build-deps ${PHP_BUILD_DEPS} \

--- a/alpine/3.15/7.4/Dockerfile
+++ b/alpine/3.15/7.4/Dockerfile
@@ -70,17 +70,17 @@ ARG CFLAGS="-I/usr/src/php"
 RUN apk update \
     && apk add --no-cache \
     bash \
+    coreutils \
     curl \
     git \
-    unzip \
     graphviz \
-    netcat-openbsd \
     mysql-client \
+    netcat-openbsd \
     openssh \
     postgresql-client \
     procps \
     shadow \
-    coreutils \
+    unzip \
     ${PHP_RUN_DEPS} \
     && \
     apk add --no-cache --virtual .php-build-deps ${PHP_BUILD_DEPS} \

--- a/alpine/3.15/8.0/Dockerfile
+++ b/alpine/3.15/8.0/Dockerfile
@@ -70,17 +70,17 @@ ARG CFLAGS="-I/usr/src/php"
 RUN apk update \
     && apk add --no-cache \
     bash \
+    coreutils \
     curl \
     git \
-    unzip \
     graphviz \
-    netcat-openbsd \
     mysql-client \
+    netcat-openbsd \
     openssh \
     postgresql-client \
     procps \
     shadow \
-    coreutils \
+    unzip \
     ${PHP_RUN_DEPS} \
     && \
     apk add --no-cache --virtual .php-build-deps ${PHP_BUILD_DEPS} \

--- a/debian/bullseye/7.3/Dockerfile
+++ b/debian/bullseye/7.3/Dockerfile
@@ -70,16 +70,16 @@ RUN apt update -y \
     && apt install -y \
     bash \
     curl \
+    default-mysql-client \
     git \
     gnupg2 \
-    unzip \
     graphviz \
+    locales-all \
     netcat-openbsd \
-    default-mysql-client \
     openssh-client \
     postgresql-client \
     procps \
-    locales-all \
+    unzip \
     wget \
     ${PHP_RUN_DEPS} \
     && \

--- a/debian/bullseye/7.4/Dockerfile
+++ b/debian/bullseye/7.4/Dockerfile
@@ -70,17 +70,17 @@ RUN apt update -y \
     && apt install -y \
     bash \
     curl \
+    default-mysql-client \
     git \
     gnupg2 \
-    unzip \
     graphviz \
+    locales-all \
     netcat-openbsd \
-    default-mysql-client \
     openssh-client \
     postgresql-client \
-    supervisor \
     procps \
-    locales-all \
+    supervisor \
+    unzip \
     wget \
     ${PHP_RUN_DEPS} \
     && \

--- a/debian/bullseye/8.0/Dockerfile
+++ b/debian/bullseye/8.0/Dockerfile
@@ -70,16 +70,16 @@ RUN apt update -y \
     && apt install -y \
     bash \
     curl \
+    default-mysql-client \
     git \
     gnupg2 \
-    unzip \
     graphviz \
+    locales-all \
     netcat-openbsd \
-    default-mysql-client \
     openssh-client \
     postgresql-client \
     procps \
-    locales-all \
+    unzip \
     wget \
     ${PHP_RUN_DEPS} \
     && \

--- a/debian/buster/7.3/Dockerfile
+++ b/debian/buster/7.3/Dockerfile
@@ -70,16 +70,16 @@ RUN apt update -y \
     && apt install -y \
     bash \
     curl \
+    default-mysql-client \
     git \
     gnupg2 \
-    unzip \
     graphviz \
+    locales-all \
     netcat-openbsd \
-    default-mysql-client \
     openssh-client \
     postgresql-client \
     procps \
-    locales-all \
+    unzip \
     wget \
     ${PHP_RUN_DEPS} \
     && \

--- a/debian/buster/7.4/Dockerfile
+++ b/debian/buster/7.4/Dockerfile
@@ -70,16 +70,16 @@ RUN apt update -y \
     && apt install -y \
     bash \
     curl \
+    default-mysql-client \
     git \
     gnupg2 \
-    unzip \
     graphviz \
+    locales-all \
     netcat-openbsd \
-    default-mysql-client \
     openssh-client \
     postgresql-client \
     procps \
-    locales-all \
+    unzip \
     wget \
     ${PHP_RUN_DEPS} \
     && \

--- a/debian/buster/8.0/Dockerfile
+++ b/debian/buster/8.0/Dockerfile
@@ -70,16 +70,16 @@ RUN apt update -y \
     && apt install -y \
     bash \
     curl \
+    default-mysql-client \
     git \
     gnupg2 \
-    unzip \
     graphviz \
+    locales-all \
     netcat-openbsd \
-    default-mysql-client \
     openssh-client \
     postgresql-client \
     procps \
-    locales-all \
+    unzip \
     wget \
     ${PHP_RUN_DEPS} \
     && \


### PR DESCRIPTION
This pull request

- [x] orders packages by name

💁‍♂️ Keeping packages sorted by name has the following advantages:

- it is easier to spot duplicates
- it is easier to reason about where to add a new package (given a person adding a package realizes that the list is sorted)