### PR TITLE
SC-10982: Debian. Bash as the default shell

### DIFF
--- a/debian/bullseye/7.4/Dockerfile
+++ b/debian/bullseye/7.4/Dockerfile
@@ -100,7 +100,8 @@ RUN apt update -y \
     && rm -rf /tmp/pear \
     && docker-php-ext-enable ${PHP_EXTENSIONS} redis \
     && apt remove -y $PHP_BUILD_DEPS \
-    && apt clean
+    && apt clean \
+    && ln -sf /bin/bash /bin/sh
 
 # Blackfire
 ENV BLACKFIRE_AGENT_SOCKET=''

--- a/debian/bullseye/8.0/Dockerfile
+++ b/debian/bullseye/8.0/Dockerfile
@@ -99,7 +99,8 @@ RUN apt update -y \
     && rm -rf /tmp/pear \
     && docker-php-ext-enable ${PHP_EXTENSIONS} redis \
     && apt remove -y $PHP_BUILD_DEPS \
-    && apt clean
+    && apt clean \
+    && ln -sf /bin/bash /bin/sh
 
 # Blackfire
 ENV BLACKFIRE_AGENT_SOCKET=''

--- a/debian/bullseye/8.1/Dockerfile
+++ b/debian/bullseye/8.1/Dockerfile
@@ -99,7 +99,8 @@ RUN apt update -y \
     && rm -rf /tmp/pear \
     && docker-php-ext-enable ${PHP_EXTENSIONS} redis \
     && apt remove -y $PHP_BUILD_DEPS \
-    && apt clean
+    && apt clean \
+    && ln -sf /bin/bash /bin/sh
 
 # Blackfire
 ENV BLACKFIRE_AGENT_SOCKET=''


### PR DESCRIPTION
## Tickets:
- https://spryker.atlassian.net/browse/SC-10985

## PR Description

- Set `/bin/bash` as the default shell for Debian.
