### PR TITLE
APPS-6668: Extend newrelic.ini config

### DIFF
--- a/context/php/disabled/newrelic.ini
+++ b/context/php/disabled/newrelic.ini
@@ -3,12 +3,28 @@ newrelic.enabled = ${NEWRELIC_ENABLED}
 newrelic.license = ${NEWRELIC_LICENSE}
 newrelic.appname = ${NEWRELIC_APPNAME}
 newrelic.framework = "no_framework"
-newrelic.browser_monitoring.auto_instrument = false
 newrelic.daemon.location = "/usr/bin/newrelic-daemon"
+
+;Logging
+newrelic.daemon.logfile = ${NEWRELIC_DAEMON_LOGFILE}
+newrelic.logfile = ${NEWRELIC_LOGFILE}
+newrelic.loglevel = ${NEWRELIC_LOGLEVEL}
+
+;Timeouts
+newrelic.daemon.app_timeout = ${NEWRELIC_DAEMON_APP_TIMEOUT}
+newrelic.daemon.app_connect_timeout = ${NEWRELIC_DAEMON_APP_CONNECT_TIMEOUT}
 
 ;Distributed tracing
 newrelic.distributed_tracing_enabled = ${NEWRELIC_DISTRIBUTED_TRACING_ENABLED}
 newrelic.transaction_tracer.enabled = ${NEWRELIC_TRANSACTION_TRACER_ENABLED}
+newrelic.transaction_tracer.stack_trace_threshold = ${NEWRELIC_TRANSACTION_TRACER_STACK_TRACE_THRESHOLD}
+newrelic.transaction_tracer.max_segments_cli = ${NEWRELIC_TRANSACTION_TRACER_MAX_SEGMENTS_CLI}
 newrelic.span_events_enabled = ${NEWRELIC_SPAN_EVENTS_ENABLED}
+newrelic.span_events.max_samples_stored = ${NEWRELIC_SPAN_EVENTS_MAX_SAMPLES_STORED}
 newrelic.transaction_tracer.threshold = ${NEWRELIC_TRANSACTION_TRACER_THRESHOLD}
 newrelic.distributed_tracing_exclude_newrelic_header = ${NEWRELIC_DISTRIBUTED_TRACING_EXCLUDE_NEWRELIC_HEADER}
+
+;Browser monitoring
+newrelic.browser_monitoring.auto_instrument = false
+newrelic.browser_monitoring.capture_attributes = ${NEWRELIC_BROWSER_MONITORING_CAPTURE_ATTRIBUTES}
+newrelic.browser_monitoring.debug = ${NEWRELIC_BROWSER_MONITORING_DEBUG}

--- a/context/php/disabled/newrelic.ini
+++ b/context/php/disabled/newrelic.ini
@@ -28,3 +28,6 @@ newrelic.distributed_tracing_exclude_newrelic_header = ${NEWRELIC_DISTRIBUTED_TR
 newrelic.browser_monitoring.auto_instrument = false
 newrelic.browser_monitoring.capture_attributes = ${NEWRELIC_BROWSER_MONITORING_CAPTURE_ATTRIBUTES}
 newrelic.browser_monitoring.debug = ${NEWRELIC_BROWSER_MONITORING_DEBUG}
+
+;Errors inbox
+newrelic.error_collector.ignore_exceptions = ${NEWRELIC_ERROR_COLLECTOR_IGNORE_EXCEPTIONS}


### PR DESCRIPTION
## PR Description

In the ACP team we'd like to make more NewRelic agent settings configurable via environment variables. Without that we have to override containers' entrypoints to make changes to this file, which is more difficult to maintain.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
