### PR TITLE
PHP 8.4 Alpine 3.20 to Alpine 3.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             tags: [ "spryker/php:8.3", "spryker/php:8.3-alpine3.20" ]
             platforms: [ "linux/amd64", "linux/arm64" ]
           - image: "alpine/3.20/8.4/Dockerfile"
-            tags: [ "spryker/php:8.4", "spryker/php:8.4-alpine3.20" ]
+            tags: [ "spryker/php:8.4-alpine3.20" ]
             platforms: [ "linux/amd64", "linux/arm64" ]
 
           ### Alpine 3.21
@@ -47,7 +47,7 @@ jobs:
             tags: [ "spryker/php:8.3-alpine3.21" ]
             platforms: [ "linux/amd64", "linux/arm64" ]
           - image: "alpine/3.21/8.4/Dockerfile"
-            tags: [ "spryker/php:8.4-alpine3.21" ]
+            tags: [ "spryker/php:8.4", "spryker/php:8.4-alpine3.21" ]
             platforms: [ "linux/amd64", "linux/arm64" ]
 
           ### Alpine 3.22


### PR DESCRIPTION
## PR Description

### Improvements

- Migrated PHP 8.4 from Alpine 3.20 to 3.21.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
